### PR TITLE
fix: 删除出问题的rules

### DIFF
--- a/conf/template.yaml
+++ b/conf/template.yaml
@@ -22,7 +22,6 @@ dns:
 # Proxies and proxy groups will be inserted here
 
 rules:
-    - 'DOMAIN-SUFFIX,copilot.microsoft.com,悠兔'
     - 'DOMAIN-SUFFIX,steamcontent.com,DIRECT'
     - 'DOMAIN-SUFFIX,steamstatic.com,DIRECT'
     - 'DOMAIN-SUFFIX,steamserver.net,DIRECT'
@@ -50,4 +49,3 @@ rules:
     - 'IP-CIDR,185.25.182.0/23,DIRECT'
     - 'IP-CIDR,208.78.164.0/22,DIRECT'
     - 'GEOIP,CN,DIRECT'
-    - 'MATCH,悠兔'


### PR DESCRIPTION
这两个rules中的代理组‘悠兔’是作者的机场的代理组，不同用户的名称不一样，一般机场的配置中都会包含这些规则，因此在这里直接把硬编码的错误rules去掉